### PR TITLE
👷 Travis CI: Upgrade to Python 3.7, drop sudo, add xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-sudo: required
+dist: xenial
 
 language: python
 
 python:
-  - "3.6"
+  - "3.7"
 
 install:
   - pip install docker pytest


### PR DESCRIPTION
__sudo: required__ no longer is...  [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

__dist: xenial__ is required for Python >= 3.7